### PR TITLE
Add a CyberOS Mirror

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=cyberos-mirrorlist
 pkgver=20210508
-pkgrel=1
+pkgrel=2
 pkgdesc="CyberOS mirror list for use by pacman"
 arch=('any')
 url="https://github.com/cyberos/cyberos-mirrorlist"
 license=('GPL')
 backup=(etc/pacman.d/cyberos-mirrorlist)
 source=(mirrorlist)
-md5sums=('9f324d5cc952cb92456f1f30afc03b9c')
+md5sums=('0c39e82ebda159d3f5200dc5063a7445')
 
 package() {
 	mkdir -p "$pkgdir/etc/pacman.d"

--- a/mirrorlist
+++ b/mirrorlist
@@ -3,5 +3,10 @@
 ## Last updated: 2021-05-08
 ##
 
+## Tier 2 mirrors
+## Germany
+Server = https://cyber.lukgth.de/$repo/os/$arch
+
+## Tier 1 mirrors
 ## Germany
 Server = https://dir.omame.tech/mirrors/cyberos/$repo/os/$arch


### PR DESCRIPTION
This PR adds my CyberOS mirror. Rsync is available under `rsync://v.lukgth.de/cyberos`. The mirror is synced everyday at 0:00 CEST. 