### PR TITLE
Urgent fix: removing space after $arch

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,7 @@ url="https://github.com/cyberos/cyberos-mirrorlist"
 license=('GPL')
 backup=(etc/pacman.d/cyberos-mirrorlist)
 source=(mirrorlist)
-md5sums=('6e2d288c1f47df74f0c052be1155800f')
+md5sums=('5dd3d64b8bda10385d29dcff6a5aa16c')
 
 package() {
 	mkdir -p "$pkgdir/etc/pacman.d"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: omame <me@omame.tech>
 
 pkgname=cyberos-mirrorlist
-pkgver=20210511
+pkgver=20210512
 pkgrel=1
 pkgdesc="CyberOS mirror list for use by pacman"
 arch=('any')
@@ -9,7 +9,7 @@ url="https://github.com/cyberos/cyberos-mirrorlist"
 license=('GPL')
 backup=(etc/pacman.d/cyberos-mirrorlist)
 source=(mirrorlist)
-md5sums=('58d45334d02a6870460438d97b1e7e09')
+md5sums=('6e2d288c1f47df74f0c052be1155800f')
 
 package() {
 	mkdir -p "$pkgdir/etc/pacman.d"

--- a/mirrorlist
+++ b/mirrorlist
@@ -5,17 +5,22 @@
 
 ## Tier 2 mirrors
 ## Canada
-Server = https://cyber.123780.xyz/$repo/os/$arch# @darksunlight
+# @darksunlight
+Server = https://cyber.123780.xyz/$repo/os/$arch
 
 ## Japan
-Server = https://cyber-jp.123780.xyz/$repo/os/$arch# @darksunlight
+# @darksunlight
+Server = https://cyber-jp.123780.xyz/$repo/os/$arch
 
 ## Russia
-Server = https://cyber.kittyle.org/$repo/os/$arch# @KittyLe
+# @KittyLe
+Server = https://cyber.kittyle.org/$repo/os/$arch
 
 ## Tier 1 mirrors
 ## Germany
-Server = https://cyber.lukgth.de/$repo/os/$arch# @lukgth
+# @lukgth
+Server = https://cyber.lukgth.de/$repo/os/$arch
 
 ## Root mirror
-Server = https://dir.omame.tech/mirrors/cyberos/$repo/os/$arch# @omaemae
+# @omaemae
+Server = https://dir.omame.tech/mirrors/cyberos/$repo/os/$arch

--- a/mirrorlist
+++ b/mirrorlist
@@ -5,17 +5,17 @@
 
 ## Tier 2 mirrors
 ## Canada
-Server = https://cyber.123780.xyz/$repo/os/$arch # @darksunlight
+Server = https://cyber.123780.xyz/$repo/os/$arch# @darksunlight
 
 ## Japan
-Server = https://cyber-jp.123780.xyz/$repo/os/$arch # @darksunlight
+Server = https://cyber-jp.123780.xyz/$repo/os/$arch# @darksunlight
 
 ## Russia
-Server = https://cyber.kittyle.org/$repo/os/$arch # @KittyLe
+Server = https://cyber.kittyle.org/$repo/os/$arch# @KittyLe
 
 ## Tier 1 mirrors
 ## Germany
-Server = https://cyber.lukgth.de/$repo/os/$arch # @lukgth
+Server = https://cyber.lukgth.de/$repo/os/$arch# @lukgth
 
 ## Root mirror
-Server = https://dir.omame.tech/mirrors/cyberos/$repo/os/$arch # @omaemae
+Server = https://dir.omame.tech/mirrors/cyberos/$repo/os/$arch# @omaemae


### PR DESCRIPTION
The space after $arch is causing all requests to the mirror to fail, as the path becomes .../os/x86_64%20